### PR TITLE
chore(deps): update renovate annotations

### DIFF
--- a/cluster/apps/default/hajimari/helm-release.yaml
+++ b/cluster/apps/default/hajimari/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://hajimari.io
       chart: hajimari
       version: 1.2.0
       sourceRef:

--- a/cluster/apps/falco-system/falco/helm-release.yaml
+++ b/cluster/apps/falco-system/falco/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://falcosecurity.github.io/charts
       chart: falco
       version: 1.16.4
       sourceRef:

--- a/cluster/apps/falco-system/falcosidekick/helm-release.yaml
+++ b/cluster/apps/falco-system/falcosidekick/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://falcosecurity.github.io/charts
       chart: falcosidekick
       version: 0.4.4
       sourceRef:

--- a/cluster/apps/goldilocks/helm-release.yaml
+++ b/cluster/apps/goldilocks/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.fairwinds.com/stable
       chart: goldilocks
       version: 5.2.0
       sourceRef:

--- a/cluster/apps/goldilocks/vpa/helm-release.yaml
+++ b/cluster/apps/goldilocks/vpa/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.fairwinds.com/stable
       chart: vpa
       version: 1.0.0
       sourceRef:

--- a/cluster/apps/kube-system/descheduler/helm-release.yaml
+++ b/cluster/apps/kube-system/descheduler/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/descheduler
       chart: descheduler
       version: 0.22.1
       sourceRef:

--- a/cluster/apps/kube-system/intel-gpu-plugin/helm-release.yaml
+++ b/cluster/apps/kube-system/intel-gpu-plugin/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: intel-gpu-plugin
       version: 4.2.0
       sourceRef:

--- a/cluster/apps/kube-system/metrics-server/helm-release.yaml
+++ b/cluster/apps/kube-system/metrics-server/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/metrics-server
       chart: metrics-server
       version: 3.7.0
       sourceRef:

--- a/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
+++ b/cluster/apps/kube-system/node-feature-discovery/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/node-feature-discovery/charts
       chart: node-feature-discovery
       version: 0.10.1
       sourceRef:

--- a/cluster/apps/kube-system/reloader/helm-release.yaml
+++ b/cluster/apps/kube-system/reloader/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://stakater.github.io/stakater-charts
       chart: reloader
       version: v0.0.104
       sourceRef:

--- a/cluster/apps/media/bazarr/helm-release.yaml
+++ b/cluster/apps/media/bazarr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: bazarr
       version: 10.3.0
       sourceRef:

--- a/cluster/apps/media/overseerr/helm-release.yaml
+++ b/cluster/apps/media/overseerr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: overseerr
       version: 5.2.0
       sourceRef:

--- a/cluster/apps/media/plex/helm-release.yaml
+++ b/cluster/apps/media/plex/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: plex
       version: 6.2.0
       sourceRef:

--- a/cluster/apps/media/prowlarr/helm-release.yaml
+++ b/cluster/apps/media/prowlarr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: prowlarr
       version: 4.2.0
       sourceRef:

--- a/cluster/apps/media/qbittorrent-vpn/helm-release.yaml
+++ b/cluster/apps/media/qbittorrent-vpn/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: qbittorrent
       version: 13.2.0
       sourceRef:

--- a/cluster/apps/media/qbittorrent/helm-release.yaml
+++ b/cluster/apps/media/qbittorrent/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: qbittorrent
       version: 13.2.0
       sourceRef:

--- a/cluster/apps/media/radarr/helm-release.yaml
+++ b/cluster/apps/media/radarr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: radarr
       version: 15.2.0
       sourceRef:

--- a/cluster/apps/media/readarr/helm-release.yaml
+++ b/cluster/apps/media/readarr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: readarr
       version: 6.2.0
       sourceRef:

--- a/cluster/apps/media/sabnzbd/helm-release.yaml
+++ b/cluster/apps/media/sabnzbd/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: sabnzbd
       version: 9.2.0
       sourceRef:

--- a/cluster/apps/media/sonarr/helm-release.yaml
+++ b/cluster/apps/media/sonarr/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: sonarr
       version: 15.3.0
       sourceRef:

--- a/cluster/apps/media/tautulli/helm-release.yaml
+++ b/cluster/apps/media/tautulli/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: tautulli
       version: 11.2.0
       sourceRef:

--- a/cluster/apps/monitoring/botkube/helm-release.yaml
+++ b/cluster/apps/monitoring/botkube/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://infracloudio.github.io/charts
       chart: botkube
       version: v0.12.4
       sourceRef:

--- a/cluster/apps/monitoring/grafana/helm-release.yaml
+++ b/cluster/apps/monitoring/grafana/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
       chart: grafana
       version: 6.21.1
       sourceRef:

--- a/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
+++ b/cluster/apps/monitoring/kube-prometheus-stack/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
       version: 30.2.0
       sourceRef:

--- a/cluster/apps/monitoring/loki/helm-release.yaml
+++ b/cluster/apps/monitoring/loki/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://grafana.github.io/helm-charts
       chart: loki
       version: 2.9.1
       sourceRef:

--- a/cluster/apps/monitoring/pushgateway/helm-release.yaml
+++ b/cluster/apps/monitoring/pushgateway/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://prometheus-community.github.io/helm-charts
       chart: prometheus-pushgateway
       version: 1.14.0
       sourceRef:

--- a/cluster/apps/monitoring/speedtest-exporter/helm-release.yaml
+++ b/cluster/apps/monitoring/speedtest-exporter/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: speedtest-exporter
       version: 5.2.0
       sourceRef:

--- a/cluster/apps/monitoring/thanos/helm-release.yaml
+++ b/cluster/apps/monitoring/thanos/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.bitnami.com/bitnami
       chart: thanos
       version: 9.0.1
       sourceRef:

--- a/cluster/apps/monitoring/unifi-poller/helm-release.yaml
+++ b/cluster/apps/monitoring/unifi-poller/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: unifi-poller
       version: 10.2.0
       sourceRef:

--- a/cluster/apps/networking/blocky/helm-release.yaml
+++ b/cluster/apps/networking/blocky/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: blocky
       version: 10.1.0
       sourceRef:

--- a/cluster/apps/networking/external-dns/helm-release.yaml
+++ b/cluster/apps/networking/external-dns/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/external-dns
       chart: external-dns
       version: 1.7.1
       sourceRef:

--- a/cluster/apps/networking/traefik/helm-release.yaml
+++ b/cluster/apps/networking/traefik/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://helm.traefik.io/traefik
       chart: traefik
       version: 10.9.1
       sourceRef:

--- a/cluster/apps/networking/unifi-controller/helm-release.yaml
+++ b/cluster/apps/networking/unifi-controller/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: unifi
       version: 4.6.1
       sourceRef:

--- a/cluster/apps/tools/authentik/helm-release.yaml
+++ b/cluster/apps/tools/authentik/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.goauthentik.io/
       chart: authentik
       version: 5.2.1
       sourceRef:

--- a/cluster/apps/tools/harbor/helm-release.yaml
+++ b/cluster/apps/tools/harbor/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://helm.goharbor.io/
       chart: harbor
       version: 1.8.1
       sourceRef:

--- a/cluster/apps/tools/trow/helm-release.yaml
+++ b/cluster/apps/tools/trow/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://trow.io/
       chart: trow
       version: 0.3.4
       sourceRef:

--- a/cluster/apps/tools/vaultwarden/helm-release.yaml
+++ b/cluster/apps/tools/vaultwarden/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://k8s-at-home.com/charts/
       chart: vaultwarden
       version: 4.0.0
       sourceRef:

--- a/cluster/core/cert-manager/helm-release.yaml
+++ b/cluster/core/cert-manager/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://charts.jetstack.io/
       chart: cert-manager
       version: v1.7.0
       sourceRef:

--- a/cluster/core/metallb-system/helm-release.yaml
+++ b/cluster/core/metallb-system/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://metallb.github.io/metallb
       chart: metallb
       version: 0.11.0
       sourceRef:

--- a/cluster/core/nfs-subdir-external-provisioner/helm-release-fast.yaml
+++ b/cluster/core/nfs-subdir-external-provisioner/helm-release-fast.yaml
@@ -10,6 +10,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
       chart: nfs-subdir-external-provisioner
       version: 4.0.15
       sourceRef:

--- a/cluster/core/nfs-subdir-external-provisioner/helm-release-slow.yaml
+++ b/cluster/core/nfs-subdir-external-provisioner/helm-release-slow.yaml
@@ -10,6 +10,7 @@ spec:
   interval: 5m
   chart:
     spec:
+      # renovate: registryUrl=https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
       chart: nfs-subdir-external-provisioner
       version: 4.0.15
       sourceRef:


### PR DESCRIPTION
Update HelmReleases in order for Renovate to pick up new versions of Helm charts